### PR TITLE
ci: install NSIS instead of Inno Setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Install Pandoc
         run: choco install pandoc
 
-      - name: Install Inno Setup
-        run: choco install innosetup
+      - name: Install NSIS
+        run: choco install nsis
 
       - name: Set version
         shell: pwsh


### PR DESCRIPTION
## Summary
- CI's release workflow was still installing Inno Setup (\`choco install innosetup\`), but \`build.zig\` already builds the Windows installer via \`makensis\` against \`installer/taskmon.nsi\`. Inno Setup doesn't provide \`makensis\`, so the installer build step would fail.

## Fix
- Swap the CI step to install NSIS instead (\`choco install nsis\`), which provides \`makensis\` and matches what the build already expects.